### PR TITLE
Bug(activities): Workers method return type for the informer plugin

### DIFF
--- a/activity/activity_pool.go
+++ b/activity/activity_pool.go
@@ -30,7 +30,7 @@ const doNotCompleteOnReturn = "doNotCompleteOnReturn"
 type activityPool interface {
 	Start(ctx context.Context, temporal client.Temporal) error
 	Destroy(ctx context.Context) error
-	Workers() []rrWorker.SyncWorker
+	Workers() []rrWorker.BaseProcess
 	ActivityNames() []string
 	GetActivityContext(taskToken []byte) (context.Context, error)
 }
@@ -93,8 +93,13 @@ func (pool *activityPoolImpl) Destroy(ctx context.Context) error {
 }
 
 // Workers returns list of all allocated workers.
-func (pool *activityPoolImpl) Workers() []rrWorker.SyncWorker {
-	return pool.wp.Workers()
+func (pool *activityPoolImpl) Workers() []rrWorker.BaseProcess {
+	syncWorkers := pool.wp.Workers()
+	base := make([]rrWorker.BaseProcess, 0, len(syncWorkers))
+	for i := 0; i < len(syncWorkers); i++ {
+		base = append(base, syncWorkers[i])
+	}
+	return base
 }
 
 // ActivityNames returns list of all available activity names.

--- a/activity/plugin.go
+++ b/activity/plugin.go
@@ -123,7 +123,7 @@ func (p *Plugin) RPC() interface{} {
 }
 
 // Workers returns pool workers.
-func (p *Plugin) Workers() []worker.SyncWorker {
+func (p *Plugin) Workers() []worker.BaseProcess {
 	return p.getPool().Workers()
 }
 

--- a/activity/plugin.go
+++ b/activity/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/spiral/roadrunner/v2/pkg/events"
 	"github.com/spiral/roadrunner/v2/pkg/worker"
+	"github.com/spiral/roadrunner/v2/plugins/config"
 
 	"sync"
 	"sync/atomic"
@@ -20,6 +21,9 @@ import (
 const (
 	// PluginName defines public service name.
 	PluginName = "activities"
+
+	// Main plugin name
+	RootPluginName = "temporal"
 
 	// RRMode sets as RR_MODE env variable to let worker know about the mode to run.
 	RRMode = "temporal/activity"
@@ -38,8 +42,12 @@ type Plugin struct {
 }
 
 // Init configures activity service.
-func (p *Plugin) Init(temporal client.Temporal, server server.Server, log logger.Logger) error {
+func (p *Plugin) Init(temporal client.Temporal, server server.Server, log logger.Logger, cfg config.Configurer) error {
 	const op = errors.Op("activity_plugin_init")
+	if !cfg.Has(RootPluginName) {
+		return errors.E(op, errors.Disabled)
+	}
+
 	if temporal.GetConfig().Activities == nil {
 		// no need to serve activities
 		return errors.E(op, errors.Disabled)

--- a/client/plugin.go
+++ b/client/plugin.go
@@ -52,14 +52,14 @@ type Config struct {
 // Init initiates temporal client plugin.
 func (p *Plugin) Init(cfg config.Configurer, log logger.Logger) error {
 	const op = errors.Op("temporal_client_plugin_init")
+	if !cfg.Has(PluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	p.log = log
 	p.dc = rrt.NewDataConverter(converter.GetDefaultDataConverter())
 	err := cfg.UnmarshalKey(PluginName, &p.cfg)
 	if err != nil {
 		return errors.E(op, err)
-	}
-	if p.cfg == nil {
-		return errors.E(op, errors.Disabled)
 	}
 
 	return nil

--- a/tests/src/Workflow/CancelSignalledChildWorkflow.php
+++ b/tests/src/Workflow/CancelSignalledChildWorkflow.php
@@ -28,7 +28,7 @@ class CancelSignalledChildWorkflow
         $this->status[] = 'start';
 
         // start execution
-        $scope = Workflow::newCancellationScope(
+        $scope = Workflow::async(
             function () use ($simple, $waitSignalled) {
                 $call = $simple->handler();
                 $this->status[] = 'child started';

--- a/tests/src/Workflow/CancelledMidflightWorkflow.php
+++ b/tests/src/Workflow/CancelledMidflightWorkflow.php
@@ -28,7 +28,7 @@ class CancelledMidflightWorkflow
 
         $this->status[] = 'start';
 
-        $scope = Workflow::newCancellationScope(
+        $scope = Workflow::async(
             function () use ($simple) {
                 $this->status[] = 'in scope';
                 $simple->slow('1');

--- a/tests/src/Workflow/CancelledNestedWorkflow.php
+++ b/tests/src/Workflow/CancelledNestedWorkflow.php
@@ -22,11 +22,11 @@ class CancelledNestedWorkflow
     {
         $this->status[] = 'begin';
         try {
-            yield Workflow::newCancellationScope(
+            yield Workflow::async(
                 function () {
                     $this->status[] = 'first scope';
 
-                    $scope = Workflow::newCancellationScope(
+                    $scope = Workflow::async(
                         function () {
                             $this->status[] = 'second scope';
 

--- a/tests/src/Workflow/CancelledScopeWorkflow.php
+++ b/tests/src/Workflow/CancelledScopeWorkflow.php
@@ -20,7 +20,7 @@ class CancelledScopeWorkflow
 
         $cancelled = 'not';
 
-        $scope = Workflow::newCancellationScope(
+        $scope = Workflow::async(
             function () use ($simple) {
                 yield Workflow::timer(2);
                 yield $simple->slow('hello');

--- a/tests/src/Workflow/CancelledSingleScopeWorkflow.php
+++ b/tests/src/Workflow/CancelledSingleScopeWorkflow.php
@@ -30,7 +30,7 @@ class CancelledSingleScopeWorkflow
 
         $this->status[] = 'start';
         try {
-            yield Workflow::newCancellationScope(
+            yield Workflow::async(
                 function () use ($simple) {
                     try {
                         $this->status[] = 'in scope';

--- a/tests/src/Workflow/CancelledWithCompensationWorkflow.php
+++ b/tests/src/Workflow/CancelledWithCompensationWorkflow.php
@@ -50,7 +50,7 @@ class CancelledWithCompensationWorkflow
                 $this->status[] = 'captured promise on cancelled';
             }
 
-            $scope = Workflow::newDetachedCancellationScope(
+            $scope = Workflow::asyncDetached(
                 function () use ($simple) {
                     $this->status[] = 'START rollback';
 

--- a/tests/src/Workflow/ParallelScopesWorkflow.php
+++ b/tests/src/Workflow/ParallelScopesWorkflow.php
@@ -21,11 +21,11 @@ class ParallelScopesWorkflow
             ActivityOptions::new()->withStartToCloseTimeout(5)
         );
 
-        $a = Workflow::newCancellationScope(function () use ($simple, $input) {
+        $a = Workflow::async(function () use ($simple, $input) {
             return yield $simple->echo($input);
         });
 
-        $b = Workflow::newCancellationScope(function () use ($simple, $input) {
+        $b = Workflow::async(function () use ($simple, $input) {
             return yield $simple->lower($input);
         });
 

--- a/tests/worker.php
+++ b/tests/worker.php
@@ -22,12 +22,13 @@ $worker = $factory->newWorker('default');
 
 // register all workflows
 foreach ($getClasses(__DIR__ . '/src/Workflow') as $name) {
-    $worker->registerWorkflowType('Temporal\\Tests\\Workflow\\' . $name);
+    $worker->registerWorkflowTypes('Temporal\\Tests\\Workflow\\' . $name);
 }
 
 // register all activity
 foreach ($getClasses(__DIR__ . '/src/Activity') as $name) {
-    $worker->registerActivityType('Temporal\\Tests\\Activity\\' . $name);
+    $class = 'Temporal\\Tests\\Activity\\' . $name;
+    $worker->registerActivityImplementations(new $class);
 }
 
 $factory->run();

--- a/workflow/plugin.go
+++ b/workflow/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spiral/errors"
 	"github.com/spiral/roadrunner/v2/pkg/events"
 	"github.com/spiral/roadrunner/v2/pkg/worker"
+	"github.com/spiral/roadrunner/v2/plugins/config"
 	"github.com/spiral/roadrunner/v2/plugins/logger"
 	"github.com/spiral/roadrunner/v2/plugins/server"
 	"github.com/temporalio/roadrunner-temporal/client"
@@ -18,6 +19,9 @@ import (
 const (
 	// PluginName defines public service name.
 	PluginName = "workflows"
+
+	// Main plugin name
+	RootPluginName = "temporal"
 
 	// RRMode sets as RR_MODE env variable to let worker know about the mode to run.
 	RRMode = "temporal/workflow"
@@ -36,7 +40,11 @@ type Plugin struct {
 }
 
 // Init workflow plugin.
-func (p *Plugin) Init(temporal client.Temporal, server server.Server, log logger.Logger) error {
+func (p *Plugin) Init(temporal client.Temporal, server server.Server, log logger.Logger, cfg config.Configurer) error {
+	const op = errors.Op("workflow_plugin_init")
+	if !cfg.Has(RootPluginName) {
+		return errors.E(op, errors.Disabled)
+	}
 	p.temporal = temporal
 	p.server = server
 	p.events = events.NewEventsHandler()


### PR DESCRIPTION
# Reason for This PR

closes #26 

## Description of Changes

1. Fix the return type of the `Workers` method in the activities plugin. `SyncWorker` -> `BaseProcess`
2. Fix PHP tests according to the latest `sdk-php` dev-master.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`) or (`git commit -S`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
