### PR TITLE
feat(protocol): Explicitly pass panic message

### DIFF
--- a/workflow/process.go
+++ b/workflow/process.go
@@ -314,7 +314,8 @@ func (wf *workflowProcess) handleMessage(msg rrt.Message) error {
 		}
 
 	case *rrt.Panic:
-		return errors.E(op, errors.Str(command.Message))
+		// do not wrap error to pass it directly to Temporal
+		return bindings.ConvertFailureToError(msg.Failure, wf.env.GetDataConverter())
 
 	default:
 		return errors.E(op, errors.Str("undefined command"))


### PR DESCRIPTION
# Reason for This PR
The current implementation does not pass the failure to the workflow log. Instead, it uses the legacy "Message" field with an additional prefix which does not play well in Temporal UI.

## Description of Changes
The panic message now passed explicitly to the workflow engine and log without any extra modifications. The failure message converted using the default FailureToError function provided by Temporal. No user changes.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

~- [ ] All commits in this PR are signed (`git commit -s`).~
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.