### PR TITLE
🐛 bug(process:close): Run command directly instead of pushing it to the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+vnext
+-------------------
+-🪛 Use `runCommand` instead of `pushCommand` due to phantom unexpected responses in the workflow process `Close` method.
+
 v1.0.0 (02.03.2021)
 -------------------
 - ⬆️ Update temporal in the `docker-compose.yaml` to `1.7.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 vnext
 -------------------
--🪛 Use `runCommand` instead of `pushCommand` due to phantom unexpected responses in the workflow process `Close` method.
+-🪛 Use `runCommand` instead of `pushCommand` because of phantom unexpected responses in the workflow process `Close` method.
 
 v1.0.0 (02.03.2021)
 -------------------

--- a/tests/src/Workflow/CancelledMidflightWorkflow.php
+++ b/tests/src/Workflow/CancelledMidflightWorkflow.php
@@ -23,7 +23,7 @@ class CancelledMidflightWorkflow
     {
         $simple = Workflow::newActivityStub(
             SimpleActivity::class,
-            ActivityOptions::new()->withStartToCloseTimeout(5)
+            ActivityOptions::new()->withStartToCloseTimeout(500)
         );
 
         $this->status[] = 'start';

--- a/workflow/process.go
+++ b/workflow/process.go
@@ -121,11 +121,9 @@ func (wf *workflowProcess) StackTrace() string {
 
 // Close the workflow.
 func (wf *workflowProcess) Close() {
-	_ = wf.mq.pushCommand(
-		rrt.DestroyWorkflow{RunID: wf.env.WorkflowInfo().WorkflowExecution.RunID},
-		nil,
-	)
-
+	// send destroy command
+	_, _ = wf.runCommand(rrt.DestroyWorkflow{RunID: wf.env.WorkflowInfo().WorkflowExecution.RunID}, nil)
+	// flush queue
 	_, _ = wf.discardQueue()
 }
 


### PR DESCRIPTION
# Reason for This PR

closes #42 

## Description of Changes

-🪛 use `runCommand` instead of `pushCommand`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
