### PR TITLE
bug(workflow): fixes the bug causing the panic on temporal client when child workflow id can not be allocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+v1.0.9 (--.07.2021)
+-------------------
+
+## 🩹 Fixes:
+
+- 🐛 Fix invalid child workflow ID error propagation to PHP worker. [BUG](https://github.com/temporalio/sdk-php/issues/113)
+
 v1.0.8 (30.06.2021)
 -------------------
 

--- a/tests/child_test.go
+++ b/tests/child_test.go
@@ -32,6 +32,28 @@ func Test_ExecuteChildWorkflow(t *testing.T) {
 	wg.Wait()
 }
 
+func Test_ExecuteChildWorkflowWithError(t *testing.T) {
+	stopCh := make(chan struct{}, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	s := NewTestServer(t, stopCh, wg, false)
+
+	w, err := s.Client().ExecuteWorkflow(
+		context.Background(),
+		client.StartWorkflowOptions{
+			TaskQueue: "default",
+		},
+		"WithChild2Workflow",
+		"Hello World",
+	)
+	assert.NoError(t, err)
+
+	var result string
+	assert.Error(t, w.Get(context.Background(), &result))
+	stopCh <- struct{}{}
+	wg.Wait()
+}
+
 func Test_ExecuteChildStubWorkflow(t *testing.T) {
 	stopCh := make(chan struct{}, 1)
 	wg := &sync.WaitGroup{}

--- a/tests/src/Workflow/WithChild2Workflow.php
+++ b/tests/src/Workflow/WithChild2Workflow.php
@@ -10,7 +10,7 @@ use Temporal\Workflow\WorkflowMethod;
 #[Workflow\WorkflowInterface]
 class WithChild2Workflow
 {
-    #[WorkflowMethod(name: 'WithChildWorkflow')]
+    #[WorkflowMethod(name: 'WithChild2Workflow')]
     public function handler(
         string $input
     ): iterable {

--- a/tests/src/Workflow/WithChild2Workflow.php
+++ b/tests/src/Workflow/WithChild2Workflow.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Tests\Workflow;
+
+use Temporal\Workflow;
+use Temporal\Workflow\WorkflowMethod;
+
+#[Workflow\WorkflowInterface]
+class WithChild2Workflow
+{
+    #[WorkflowMethod(name: 'WithChildWorkflow')]
+    public function handler(
+        string $input
+    ): iterable {
+        $result = yield Workflow::executeChildWorkflow(
+            'SimpleWorkflow',
+            ['child ' . $input],
+            Workflow\ChildWorkflowOptions::new()
+                ->withWorkflowID('abc')
+        );
+
+        $result = yield Workflow::executeChildWorkflow(
+            'SimpleWorkflow',
+            ['child ' . $input],
+            Workflow\ChildWorkflowOptions::new()
+                ->withWorkflowID('abc')
+        );
+
+        return 'Child: ' . $result;
+    }
+}

--- a/workflow/process.go
+++ b/workflow/process.go
@@ -212,9 +212,9 @@ func (wf *workflowProcess) handleMessage(msg rrt.Message) error {
 		wf.ids.listen(command.ID, func(w bindings.WorkflowExecution, err error) {
 			cl := wf.createCallback(msg.ID)
 
-			// TODO rewrite
 			if err != nil {
-				panic(err)
+				cl(nil, err)
+				return
 			}
 
 			p, er := wf.env.GetDataConverter().ToPayloads(w)


### PR DESCRIPTION
# Reason for This PR
closes https://github.com/temporalio/sdk-php/issues/113

## Description of Changes

Properly pass the error to the underlying PHP worker.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.