### PR TITLE
fix: use LA pool for the local activities execution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["stretchr"]
-}

--- a/aggregatedpool/handler.go
+++ b/aggregatedpool/handler.go
@@ -146,7 +146,7 @@ func (wp *Workflow) handleMessage(msg *internal.Message) error {
 
 	case *internal.ExecuteLocalActivity:
 		wp.log.Debug("local activity request", zap.Uint64("ID", msg.ID))
-		params := command.LocalActivityParams(wp.env, NewLocalActivityFn(msg.Header, wp.codec, wp.pool, wp.log).execute, msg.Payloads, msg.Header)
+		params := command.LocalActivityParams(wp.env, wp.la, msg.Payloads, msg.Header)
 		activityID := wp.env.ExecuteLocalActivity(params, wp.createLocalActivityCallback(msg.ID))
 		wp.canceller.Register(msg.ID, func() error {
 			wp.log.Debug("registering local activity canceller", zap.String("activityID", activityID.String()))

--- a/aggregatedpool/local_activity.go
+++ b/aggregatedpool/local_activity.go
@@ -18,23 +18,21 @@ import (
 )
 
 type LocalActivityFn struct {
-	header *commonpb.Header
-	codec  common.Codec
-	pool   common.Pool
-	log    *zap.Logger
-	seqID  uint64
+	codec common.Codec
+	pool  common.Pool
+	log   *zap.Logger
+	seqID uint64
 }
 
-func NewLocalActivityFn(header *commonpb.Header, codec common.Codec, pool common.Pool, log *zap.Logger) *LocalActivityFn {
+func NewLocalActivityFn(codec common.Codec, pool common.Pool, log *zap.Logger) *LocalActivityFn {
 	return &LocalActivityFn{
-		header: header,
-		codec:  codec,
-		pool:   pool,
-		log:    log,
+		codec: codec,
+		pool:  pool,
+		log:   log,
 	}
 }
 
-func (la *LocalActivityFn) execute(ctx context.Context, args *commonpb.Payloads) (*commonpb.Payloads, error) {
+func (la *LocalActivityFn) ExecuteLA(ctx context.Context, hdr *commonpb.Header, args *commonpb.Payloads) (*commonpb.Payloads, error) {
 	const op = errors.Op("activity_pool_execute_activity")
 
 	var info = tActivity.GetInfo(ctx)
@@ -53,7 +51,7 @@ func (la *LocalActivityFn) execute(ctx context.Context, args *commonpb.Payloads)
 			Info: info,
 		},
 		Payloads: args,
-		Header:   la.header,
+		Header:   hdr,
 	}
 
 	la.log.Debug("executing local activity fn", zap.Uint64("ID", msg.ID), zap.String("task-queue", info.TaskQueue), zap.String("la ID", info.ActivityID))

--- a/aggregatedpool/workflow.go
+++ b/aggregatedpool/workflow.go
@@ -90,7 +90,7 @@ func NewWorkflowDefinition(codec common.Codec, la LaFn, pool common.Pool, log *z
 
 // NewWorkflowDefinition ... Workflow should match the WorkflowDefinitionFactory interface (sdk-go/internal/internal_worker.go:463, RegisterWorkflowWithOptions func)
 // DO NOT USE THIS FUNCTION DIRECTLY!!!!
-// This function called after the constructor above, it is same to assign fields like that
+// This function called after the constructor above, it is safe to assign fields like that
 func (wp *Workflow) NewWorkflowDefinition() bindings.WorkflowDefinition {
 	return &Workflow{
 		rrID: uuid.NewString(),
@@ -153,7 +153,7 @@ func (wp *Workflow) Execute(env bindings.WorkflowEnvironment, header *commonpb.H
 	)
 }
 
-// OnWorkflowTaskStarted is called for each non timed out startWorkflowTask event.
+// OnWorkflowTaskStarted is called for each non-timed out startWorkflowTask event.
 // Executed after all history events since the previous commands are applied to WorkflowDefinition
 // Application level code must be executed from this function only.
 // Execute call as well as callbacks called from WorkflowEnvironment functions can only schedule callbacks

--- a/internal.go
+++ b/internal.go
@@ -28,7 +28,10 @@ func (p *Plugin) initPool() error {
 	dc := data_converter.NewDataConverter(converter.GetDefaultDataConverter())
 	codec := proto.NewCodec(p.log, dc)
 
+	// LA + A definitions
 	actDef := aggregatedpool.NewActivityDefinition(codec, ap, p.log)
+	laDef := aggregatedpool.NewLocalActivityFn(codec, ap, p.log)
+	// ------------------
 
 	// ---------- WORKFLOW POOL -------------
 	wp, err := p.server.NewPool(
@@ -48,7 +51,7 @@ func (p *Plugin) initPool() error {
 		return err
 	}
 
-	wfDef := aggregatedpool.NewWorkflowDefinition(codec, wp, p.log)
+	wfDef := aggregatedpool.NewWorkflowDefinition(codec, laDef.ExecuteLA, wp, p.log)
 
 	// get worker information
 	wi, err := WorkerInfo(codec, wp, p.rrVersion)

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -347,11 +347,12 @@ func (cmd ExecuteLocalActivity) LocalActivityParams(env bindings.WorkflowEnviron
 		truTemOptions.RetryPolicy = rp
 	}
 
+	// TODO: should be careful here: header + inputArgs header are pointers and might be changed independently which will cause race
 	params := bindings.ExecuteLocalActivityParams{
 		ExecuteLocalActivityOptions: truTemOptions,
 		ActivityFn:                  fn,
 		ActivityType:                cmd.Name,
-		InputArgs:                   []any{payloads, header},
+		InputArgs:                   []any{header, payloads},
 		WorkflowInfo:                env.WorkflowInfo(),
 		ScheduledTime:               time.Now(),
 		Header:                      header,

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -351,7 +351,7 @@ func (cmd ExecuteLocalActivity) LocalActivityParams(env bindings.WorkflowEnviron
 		ExecuteLocalActivityOptions: truTemOptions,
 		ActivityFn:                  fn,
 		ActivityType:                cmd.Name,
-		InputArgs:                   []any{payloads},
+		InputArgs:                   []any{payloads, header},
 		WorkflowInfo:                env.WorkflowInfo(),
 		ScheduledTime:               time.Now(),
 		Header:                      header,


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1940

## Description of Changes

- WF pool was incorrectly used to execute Local Activities.
- Update implementation, use the general pool for A + LA.
- Use LA execute function directly, w/o constructor like in prev. implementation.
- Add `headers` to the `execute` function (passed to the worker).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
