### PR TITLE
feature(h2c): optional certificates for TLS

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,20 +135,24 @@ func (c *Config) InitDefault() error {
 	}
 
 	if c.TLS != nil {
-		if _, err := os.Stat(c.TLS.Key); err != nil {
-			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("key file '%s' does not exists", c.TLS.Key))
-			}
+		if c.TLS.Key != "" {
+			if _, err := os.Stat(c.TLS.Key); err != nil {
+				if os.IsNotExist(err) {
+					return errors.E(op, errors.Errorf("key file '%s' does not exists", c.TLS.Key))
+				}
 
-			return errors.E(op, err)
+				return errors.E(op, err)
+			}
 		}
 
-		if _, err := os.Stat(c.TLS.Cert); err != nil {
-			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("cert file '%s' does not exists", c.TLS.Cert))
+		if c.TLS.Cert != "" {
+			if _, err := os.Stat(c.TLS.Cert); err != nil {
+				if os.IsNotExist(err) {
+					return errors.E(op, errors.Errorf("cert file '%s' does not exists", c.TLS.Cert))
+				}
+	
+				return errors.E(op, err)
 			}
-
-			return errors.E(op, err)
 		}
 
 		// RootCA is optional, but if provided - check it


### PR DESCRIPTION
# Reason for This PR

In case of h2c there a no need to provide certificates with enabled TLS option

## Description of Changes

If TLS is enabled certificates files are optional.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
