### PR TITLE
feat: Add JSON schema, adjust documentation and defaults

### DIFF
--- a/config.go
+++ b/config.go
@@ -140,7 +140,7 @@ func (c *Config) InitDefault() error {
 	if c.TLS != nil {
 		if _, err := os.Stat(c.TLS.Key); err != nil {
 			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("Private key file '%s' does not exist.", c.TLS.Key))
+				return errors.E(op, errors.Errorf("private key file '%s' does not exist", c.TLS.Key))
 			}
 
 			return errors.E(op, err)
@@ -148,7 +148,7 @@ func (c *Config) InitDefault() error {
 
 		if _, err := os.Stat(c.TLS.Cert); err != nil {
 			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("Public certificate file '%s' does not exist.", c.TLS.Cert))
+				return errors.E(op, errors.Errorf("public certificate file '%s' does not exist", c.TLS.Cert))
 			}
 
 			return errors.E(op, err)
@@ -158,7 +158,7 @@ func (c *Config) InitDefault() error {
 		if c.TLS.RootCA != "" {
 			if _, err := os.Stat(c.TLS.RootCA); err != nil {
 				if os.IsNotExist(err) {
-					return errors.E(op, errors.Errorf("Root CA file '%s' does not exist.", c.TLS.RootCA))
+					return errors.E(op, errors.Errorf("root CA file '%s' does not exist", c.TLS.RootCA))
 				}
 				return errors.E(op, err)
 			}

--- a/config.go
+++ b/config.go
@@ -130,6 +130,9 @@ func (c *Config) InitDefault() error {
 				if c.Metrics.Statsd.HostPort == "" {
 					c.Metrics.Statsd.HostPort = "127.0.0.1:8125"
 				}
+				if c.Metrics.Statsd.FlushBytes == 0 {
+					c.Metrics.Statsd.FlushBytes = 1432
+				}
 			}
 		}
 	}
@@ -137,7 +140,7 @@ func (c *Config) InitDefault() error {
 	if c.TLS != nil {
 		if _, err := os.Stat(c.TLS.Key); err != nil {
 			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("key file '%s' does not exists", c.TLS.Key))
+				return errors.E(op, errors.Errorf("Private key file '%s' does not exist.", c.TLS.Key))
 			}
 
 			return errors.E(op, err)
@@ -145,7 +148,7 @@ func (c *Config) InitDefault() error {
 
 		if _, err := os.Stat(c.TLS.Cert); err != nil {
 			if os.IsNotExist(err) {
-				return errors.E(op, errors.Errorf("cert file '%s' does not exists", c.TLS.Cert))
+				return errors.E(op, errors.Errorf("Public certificate file '%s' does not exist.", c.TLS.Cert))
 			}
 
 			return errors.E(op, err)
@@ -155,7 +158,7 @@ func (c *Config) InitDefault() error {
 		if c.TLS.RootCA != "" {
 			if _, err := os.Stat(c.TLS.RootCA); err != nil {
 				if os.IsNotExist(err) {
-					return errors.E(op, errors.Errorf("root ca path provided, but key file '%s' does not exists", c.TLS.RootCA))
+					return errors.E(op, errors.Errorf("Root CA file '%s' does not exist.", c.TLS.RootCA))
 				}
 				return errors.E(op, err)
 			}

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,181 @@
+{
+  "$id": "https://raw.githubusercontent.com/temporalio/roadrunner-temporal/refs/heads/master/schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "description": "All the valid configuration parameters for the Temporal plugin for RoadRunner.",
+  "type": "object",
+  "title": "roadrunner-temporal",
+  "additionalProperties": false,
+  "required": [
+    "address"
+  ],
+  "properties": {
+    "address": {
+      "description": "Address of the Temporal server.",
+      "type": "string",
+      "default": "127.0.0.1:7233",
+      "minLength": 1
+    },
+    "cache_size": {
+      "description": "Sticky cache size. Sticky workflow execution is the affinity between workflow tasks of a specific workflow execution to a specific worker. The benefit of sticky execution is that the workflow does not have to reconstruct state by replaying history from the beginning. The cache is shared between workers running within same process. This must be called before any worker is started. If not called, the default size of 10K (which may change) will be used.",
+      "type": "integer",
+      "default": 10000
+    },
+    "namespace": {
+      "description": "Namespace for this client to work with.",
+      "type": "string",
+      "default": "default"
+    },
+    "metrics": {
+      "description": "Temporal metrics.",
+      "required": [
+        "driver"
+      ],
+      "properties": {
+        "driver": {
+          "description": "Metrics driver to use.",
+          "type": "string",
+          "enum": [
+            "prometheus",
+            "statsd"
+          ],
+          "default": "prometheus"
+        }
+      },
+      "if": {
+        "properties": {
+          "driver": {
+            "const": "prometheus"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "prometheus": {
+            "$ref": "#/$defs/Prometheus"
+          }
+        }
+      },
+      "else": {
+        "if": {
+          "properties": {
+            "driver": {
+              "const": "statsd"
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "statsd": {
+              "$ref": "#/$defs/Statsd"
+            }
+          }
+        },
+        "else": false
+      }
+    },
+    "activities": {
+      "$ref": "https://raw.githubusercontent.com/roadrunner-server/pool/refs/heads/master/schema.json"
+    },
+    "tls": {
+      "description": "Temporal TLS configuration.",
+      "type": "object",
+      "required": [
+        "key",
+        "cert"
+      ],
+      "properties": {
+        "key": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/SSL/properties/key"
+        },
+        "cert": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/SSL/properties/cert"
+        },
+        "root_ca": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/SSL/properties/root_ca"
+        },
+        "client_auth_type": {
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/http/refs/heads/master/schema.json#/$defs/ClientAuthType"
+        },
+        "server_name": {
+          "description": "ServerName is used to verify the hostname on the returned certificates unless InsecureSkipVerify is given. It is also included in the client's handshake to support virtual hosting unless it is an IP address.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "Statsd": {
+      "type": "object",
+      "description": "Properties for Temporal Statsd integration.",
+      "additionalProperties": false,
+      "properties": {
+        "host_port": {
+          "description": "The host and port of the statsd server.",
+          "type": "string",
+          "default": "127.0.0.1:8125",
+          "minLength": 1
+        },
+        "prefix": {
+          "description": "The prefix to use in reporting to statsd.",
+          "type": "string"
+        },
+        "flush_interval": {
+          "description": "The maximum interval between sending packets.",
+          "$ref": "https://raw.githubusercontent.com/roadrunner-server/roadrunner/refs/heads/master/schemas/config/3.0.schema.json#/definitions/Duration",
+          "default": "1s"
+        },
+        "flush_bytes": {
+          "description": "The maximum UDP packet size you wish to send. Defaults to 1432 bytes if zero or undefined, which is considered safe for local traffic.",
+          "type": "integer",
+          "default": 1432
+        },
+        "tags": {
+          "description": "A map of tags consisting of keys and values.",
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "tag_prefix": {
+          "description": "Prefix for the tags.",
+          "type": "string"
+        },
+        "tag_separator": {
+          "description": "The tag separator allows tags to be appended with a separator. If not specified, tag keys and values are embedded in the stat name directly.",
+          "type": "string"
+        }
+      }
+    },
+    "Prometheus": {
+      "type": "object",
+      "description": "Properties for Temporal Prometheus integration.",
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "description": "Server metrics address.",
+          "type": "string",
+          "default": "127.0.0.1:9091",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Metrics type to use. Defaults to `summary`.",
+          "enum": [
+            "summary",
+            "histogram"
+          ],
+          "default": "summary"
+        },
+        "prefix": {
+          "description": "Temporal metrics prefix.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adjust error messages
Add documented defaults for FlushBytes

# Reason for This PR

Following my work in the roadrunner org where I've been moving all JSON schemas to the repos they belong to, here is that same change for temporal.

## Description of Changes

Added JSON schema.
Adjusted some error messages (syntax, grammar) and added default values according to documentation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
