### PR TITLE
chore: Fix broken if-else logic in JSON schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -5,14 +5,11 @@
   "type": "object",
   "title": "roadrunner-temporal",
   "additionalProperties": false,
-  "required": [
-    "address"
-  ],
   "properties": {
     "address": {
-      "description": "Address of the Temporal server.",
+      "description": "Address of the Temporal server. Defaults to localhost:7233 if not provided.",
       "type": "string",
-      "default": "127.0.0.1:7233",
+      "default": "localhost:7233",
       "minLength": 1
     },
     "cache_size": {
@@ -26,53 +23,40 @@
       "default": "default"
     },
     "metrics": {
-      "type": "object",
-      "description": "Temporal metrics.",
-      "required": [
-        "driver"
-      ],
-      "properties": {
-        "driver": {
-          "description": "Metrics driver to use.",
-          "type": "string",
-          "enum": [
-            "prometheus",
-            "statsd"
-          ],
-          "default": "prometheus"
-        }
-      },
-      "if": {
-        "properties": {
-          "driver": {
-            "const": "prometheus"
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "prometheus": {
-            "$ref": "#/$defs/Prometheus"
-          }
-        }
-      },
-      "else": {
-        "if": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
           "properties": {
             "driver": {
-              "const": "statsd"
+              "description": "The Prometheus driver.",
+              "type": "string",
+              "enum": [
+                "prometheus"
+              ]
+            },
+            "prometheus": {
+              "$ref": "#/$defs/Prometheus"
             }
           }
         },
-        "then": {
+        {
+          "type": "object",
+          "additionalProperties": false,
           "properties": {
+            "driver": {
+              "description": "The Statsd driver.",
+              "type": "string",
+              "enum": [
+                "statsd"
+              ]
+            },
             "statsd": {
               "$ref": "#/$defs/Statsd"
             }
           }
-        },
-        "else": false
-      }
+        }
+      ]
     },
     "activities": {
       "$ref": "https://raw.githubusercontent.com/roadrunner-server/pool/refs/heads/master/schema.json"


### PR DESCRIPTION
# Reason for This PR

There's a problem with the if-else logic in the schema here.

## Description of Changes

I replaced if-else with a oneOf for a valid combination of options. I have tested this locally so it should be the last PR for this repo.
Also, `address` is not required. I looked at the driver and it defaults to `localhost:7233`. I changed it only for consistency with the prometheus package; I'm aware localhost and 127.0.0.1 is the same.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
