### PR TITLE
fix: `CancelSignaledChildWorkflow` test

### DIFF
--- a/tests/php_test_files/composer.json
+++ b/tests/php_test_files/composer.json
@@ -2,7 +2,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"temporal/sdk": "^2.15.1",
+		"temporal/sdk": "^2.16.0",
 		"spiral/roadrunner-kv": "^4.0"
 	},
 	"name": "test/test",

--- a/tests/php_test_files/src/Workflow/CancelSignaledChildWorkflow.php
+++ b/tests/php_test_files/src/Workflow/CancelSignaledChildWorkflow.php
@@ -35,7 +35,7 @@ class CancelSignaledChildWorkflow
 
                 yield $simple->add(8);
                 $this->status[] = 'child signaled';
-                $waitSignaled->resolve();
+                $waitSignaled->resolve(null);
 
                 return yield $call;
             }


### PR DESCRIPTION
# Reason for This PR

React Promise v3 (cross dependency) has changed signature of the `PromiseInterface::resolve()` that requires a values as the first argument now.

## Description of Changes

Fixed `CancelSignaledChildWorkflow` test.
Increased min PHP SDK version to `2.16.0` in `composer.json`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
