### PR TITLE
fix: grant security-events write permission to the CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,11 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      # required to upload SARIF results to code scanning
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
CodeQL runs on master (push and scheduled) have been failing since June 12 at the final SARIF upload step with `Resource not accessible by integration`, for example https://github.com/temporalio/roadrunner-temporal/actions/runs/32476971204. The default workflow token became read-only around that date, and the workflow has no `permissions` block, so the upload to code scanning lacks `security-events: write`. Pull request runs still pass because code scanning accepts PR uploads on public repositories with a read-only token, which is why only push and scheduled runs are affected.

This grants the analyze job `contents: read` and `security-events: write`, restoring the upload for push and scheduled runs while keeping the restrictive default for everything else.