### PR TITLE
docs(config): say what cache_size zero actually does

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,7 +20,9 @@ type Config struct {
 
 	Address   string `mapstructure:"address"`
 	Namespace string `mapstructure:"namespace"`
-	CacheSize int    `mapstructure:"cache_size"`
+
+	// 0 = sdk-go default (10000); the sticky cache is only disabled by a negative value.
+	CacheSize int `mapstructure:"cache_size"`
 
 	// 0 = sdk-go default (60s); out-of-range values are clamped to 1s–60s (see initTemporalClient).
 	WorkerHeartbeatInterval time.Duration `mapstructure:"worker_heartbeat_interval"`

--- a/schema.json
+++ b/schema.json
@@ -13,7 +13,7 @@
       "minLength": 1
     },
     "cache_size": {
-      "description": "Sticky cache size. Sticky workflow execution is the affinity between workflow tasks of a specific workflow execution to a specific worker. The benefit of sticky execution is that the workflow does not have to reconstruct state by replaying history from the beginning. The cache is shared between workers running within same process. This must be called before any worker is started. If not called, the default size of 10K (which may change) will be used.",
+      "description": "Sticky cache size. Sticky workflow execution is the affinity between workflow tasks of a specific workflow execution to a specific worker. The benefit of sticky execution is that the workflow does not have to reconstruct state by replaying history from the beginning. The cache is shared between workers running within same process. Zero means the default of 10K, so the cache cannot be turned off that way - pass a negative value to disable sticky execution entirely.",
       "type": "integer",
       "default": 10000
     },


### PR DESCRIPTION

# Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

InitDefaults replaces a zero cache_size with 10000, so zero cannot be used to turn the sticky cache off - only a negative value does that.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
